### PR TITLE
Add `mm-j-commands.html` to regenerate-website.sh

### DIFF
--- a/regenerate-website.sh
+++ b/regenerate-website.sh
@@ -106,6 +106,7 @@ y)
         mmset.raw.html \
         mmtopstr.html \
         mmzfcnd.raw.html \
+        mm-j-commands.html \
         "$METAMATHSITE/mpegif"
     )
 


### PR DESCRIPTION
Identified as a possible step needed to get this page on the website at https://github.com/metamath/set.mm/pull/3252#issuecomment-1590560494 , which is still not on the website despite metamath/set.mm#3252 being merged for more than 24 hours. (To be fair I'm basically cargo-culting this code, these shell scripts are way too complicated to follow properly.)