### PR TITLE
Use .raw.html files from set.mm repository

### DIFF
--- a/regenerate-website.sh
+++ b/regenerate-website.sh
@@ -84,6 +84,15 @@ y)
 
     # Copy databases in.
     cp -p repos/set.mm/*.mm "$METAMATHSITE/metamath/"
+    # Copy the .raw.html files from repos/set.mm
+    cp -p repos/set.mm/mmil.raw.html "$METAMATHSITE/ilegif/mmil.raw.html"
+    cp -p repos/set.mm/mmcomplex.raw.html "$METAMATHSITE/mpegif/mmcomplex.raw.html"
+    cp -p repos/set.mm/mmdeduction.raw.html "$METAMATHSITE/mpegif/mmdeduction.raw.html"
+    cp -p repos/set.mm/mmfrege.raw.html "$METAMATHSITE/mpegif/mmfrege.raw.html"
+    cp -p repos/set.mm/mmnatded.raw.html "$METAMATHSITE/mpegif/mmnatded.raw.html"
+    cp -p repos/set.mm/mmset.raw.html "$METAMATHSITE/mpegif/mmset.raw.html"
+    cp -p repos/set.mm/mmzfcnd.raw.html "$METAMATHSITE/mpegif/mmzfcnd.raw.html"
+    cp -p reops/set.mm/mmnf.raw.html "$METAMATHSITE/nfegif/mmnf.raw.html"
 
     cd "$METAMATHSITE"
     sh -x "$HOME/install.sh" >install.log 2>&1


### PR DESCRIPTION
Those are the copies that we have been maintaining, but until now what has been used in the live site are the copies from metamath-website-seed Assuming this works, we can remove the copies in metamath-website-seed which are out of date anyway.

There's a more full diagnosis at https://github.com/metamath/metamath-website-seed/pull/14#issuecomment-1732751926

Steps:

1. get review on this pull request (ideally from @digama0 or @david-a-wheeler )
2. merge it
3. wait a day for the nightly website rebuild to happen
4. look at whether all 8 files are present in the generated site and whether they are the up to date copies from the set.mm repo
5. if yes, celebrate a little and figure we are good on https://github.com/metamath/metamath-website-scripts/issues/2
6. add `nfegif/mmnf.raw.html` to https://github.com/metamath/metamath-website-seed/pull/14 (the other seven files are already there)
7. move https://github.com/metamath/metamath-website-seed/pull/14 out of draft and merge it
8. wait a day for the nightly website rebuild to happen
9. make sure nothing broke in step 7 (it shouldn't have, but with these scripts you never know) by looking at whether all 8 files are present in the generated site